### PR TITLE
HH-136784 Do not reconnect on tab reload

### DIFF
--- a/lib/client/ClientSocket.js
+++ b/lib/client/ClientSocket.js
@@ -21,6 +21,7 @@ class ClientSocket {
     this.eventHandlers = [];
     this.options = options;
     this.retrying = false;
+    this.destroyed = false;
 
     this.connect();
   }
@@ -34,18 +35,24 @@ class ClientSocket {
     this.socket.close();
   }
 
+  destroy() {
+    this.destroyed = true;
+    this.close();
+  }
+
   connect() {
     if (this.socket) {
       delete this.socket;
     }
 
+    this.destroyed = false;
     this.connecting = true;
 
     this.socket = new WebSocket(...this.args);
 
     if (this.options.retry) {
       this.socket.addEventListener('close', (event) => {
-        if (ignoreCodes.includes(event.code)) {
+        if (this.destroyed || ignoreCodes.includes(event.code)) {
           return;
         }
 

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -31,7 +31,7 @@ const run = (buildHash, options) => {
   window.webpackPluginServe.compilers[compilerName] = {};
 
   // prevents ECONNRESET errors on the server
-  window.addEventListener('beforeunload', () => socket.close());
+  window.addEventListener('beforeunload', () => socket.destroy());
 
   socket.addEventListener('message', (message) => {
     const { action, data = {} } = JSON.parse(message.data);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hh.ru/webpack-plugin-serve",
-  "version": "1.5.0-patch",
+  "version": "1.5.0-patch.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hh.ru/webpack-plugin-serve",
-  "version": "1.5.0-patch.2",
+  "version": "1.5.0-patch.3",
   "description": "A Development Server in a Webpack Plugin",
   "license": "MPL-2.0",
   "repository": "shellscape/webpack-plugin-serve",


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-136784

При перезагрузке страницы срабатывает beforeunload, который вызывает close, но тут же пытается переподключиться, пока страница еще не начала отдавать данные, что вызывает спам на сервере и потенциально увеличивает шанс на ошибки IO нодовского сокета.

Решение: в beforeunload закрываем соединение навсегда (до следующей загрузки скрипта)